### PR TITLE
Add perf recording support

### DIFF
--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -677,7 +677,11 @@ def Main():
     parser.add_argument('--enable-startup-tracing', action=argparse.BooleanOptionalAction,
                         help="Enable/disable tracing on service startup")
     parser.add_argument('--get-startup-tracing', action="store_true",
-                        help="Check if the the service will start tracing on startup")
+                        help="Check if the service will start tracing on startup")
+    parser.add_argument('--enable-perf-recording', action=argparse.BooleanOptionalAction,
+                        help="Enable/disable perf recording when tracing.")
+    parser.add_argument('--get-perf-recording', action="store_true",
+                        help="Check if the service will run pref alongside trace-cmd.")
 
     # Rpc commands
     parser.add_argument('--capture', action="store_true", dest="command_capture",
@@ -719,6 +723,10 @@ def Main():
         State().config.SetConfigValue("StartupCapture", args.enable_startup_tracing)
     elif args.get_startup_tracing:
         print( "1" if State().config.GetConfigValue("StartupCapture", None) else "0" )
+    elif args.enable_perf_recording is not None:
+        State().config.SetConfigValue("PerfRecording", args.enable_perf_recording)
+    elif args.get_perf_recording:
+        print( "1" if State().config.GetConfigValue("PerfRecording", None) else "0" )
     else:
         StandaloneMain(args)
 

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -196,7 +196,7 @@ class GpuTrace:
     def __del__(self):
         if self.traceCapable:
             if self.IsTraceEnabled():
-                self.StopCapture()
+                self.StopCapture(quiet=True)
 
     def TraceSetup(self):
         try:
@@ -224,12 +224,15 @@ class GpuTrace:
         self.TraceCmd("start", "-b", "8000", "-D", "-i", self.traceEventArgs)
         Log.info("GPU Trace started")
 
-    def StopCapture(self):
+    def StopCapture(self, *, quiet=False):
         if not self.IsTraceEnabled():
-            Log.error("Attempted to stop trace, but no trace was enabled")
+            if not quiet:
+                Log.error("Attempted to stop trace, but no trace was enabled")
             return
 
-        Log.info("GPU Trace stopping")
+        if not quiet:
+            Log.info("GPU Trace stopping")
+
         self.TraceCmd("reset")
         self.TraceCmd("snapshot", "-f")
         self.TraceCmd("stop")

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -350,7 +350,8 @@ class Daemon:
         self.server.serve_forever()
         Log.info('GPU Trace daemon exiting')
 
-    def ShutdownWork(self, server):
+    @staticmethod
+    def ShutdownWork(server):
         if server is not None:
             Log.info("Shutting down rpc server")
             server.shutdown()

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -147,8 +147,8 @@ def RunCommand(cmd, background=False):
 
     # Log.debug( f"Executing {execCmd}" );
     if background:
-        subprocess.Popen(cmd)
-        return ""
+        return subprocess.Popen(
+            cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     else:
         cmdProc = subprocess.run(execCmd, capture_output=True)
         # Log.debug( f"return: {cmdProc.returncode}" );

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -448,7 +448,9 @@ def StandaloneMain(args):
     State().traceExitEvent.wait()
 
     gpuTrace.CaptureTrace(args.output_dat)
-    GpuVis().OpenTrace(args.output_dat)
+
+    if args.open_gpuvis:
+        GpuVis().OpenTrace(args.output_dat)
 
 
 ####################################

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -135,7 +135,7 @@ def SetupLogging(logPath, logLevel):
 def GetBinary(name):
     path = shutil.which(name)
 
-    if not path.strip():
+    if path is None or not path.strip():
         Die(f"Failed to find binary in PATH: {name}")
 
     Log.debug(f"Found {name} at {path}")

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -514,7 +514,7 @@ def Main():
         ClientMain(args)
     elif args.enable_startup_tracing is not None:
         State().config.SetConfigValue("StartupCapture", args.enable_startup_tracing)
-    elif args.get_startup_tracing is not None:
+    elif args.get_startup_tracing:
         print( "1" if State().config.GetConfigValue("StartupCapture", None) else "0" )
     else:
         StandaloneMain(args)


### PR DESCRIPTION
This patchset adds simultaneous perf and trace-cmd capture capabilities to gpu-trace and also fixes a number of bugs I encountered along the way.

To test these changes out, first ensure that perf can be run in the context that the gpu-trace daemon is being run.  There are a number of different approaches to this [0], but if security is not a concern, the easiest for debug purposes is probably just to set /proc/sys/kernel/perf_event_paranoid to -1.  It is also necessary to have a version of perf that includes JSON conversion support, which is available upstream as d0713d4ca3 [1].  With all of that version of perf in place, it is necessary to run --enable-perf-recording as both the user that will be running the gpu-trace daemon and the user that will be running the client.  This only needs to be done once.

After following all of those steps, perf will be run in daemon mode alongside trace-cmd whenever tracing is enabled and capturing will result in captures from both perf and trace-cmd being taken.  The perf capture will automatically be converted to the appropriate JSON format (a custom filename can be specified with --output-json) and opened in gpuvis (when --no-gpuvis has not been specified).

[0] https://github.com/shwnchpl/gpu-trace/tree/feature/perf-integration
[1] https://lore.kernel.org/lkml/3884969f-804d-2f53-c648-e2b0bd85edff@codeweavers.com/