### PR TITLE
Capture standalone mode perf recording if enabled

### DIFF
--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -679,10 +679,13 @@ def StandaloneMain(args):
     State().traceExitEvent.wait()
 
     gpuTrace.CaptureTrace(args.output_dat)
+    perfCaptured = False
+    if perfTrace is not None:
+        perfCaptured = perfTrace.CaptureTrace(args.perf_json)
 
     if args.open_gpuvis:
         gpuvisArgs = [args.output_dat]
-        if perfTrace is not None and perfTrace.CaptureTrace(args.perf_json):
+        if perfCaptured:
             gpuvisArgs.append(args.perf_json)
 
         GpuVis().OpenTrace(*gpuvisArgs)


### PR DESCRIPTION
Always capture a pref recording when running in standalone mode if perf
recording is enabled, regardless of whether --no-gpuvis has been passed.

Signed-off-by: Shawn M. Chapla <schapla@codeweavers.com>