### PR TITLE
Fix postprocessing.

### DIFF
--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -814,7 +814,7 @@ def StandaloneMain(args):
     if not ok:
         Log.error( "Failed to capture trace" )
 
-    ProcessCaptureResult(tracePath, perfPath, args.open_gpuvis, args.outpath.strip() )
+    ProcessCaptureResult(tracePath, perfPath, args.open_gpuvis, args.output.strip() )
     RemoveFile(tracePath)
     RemoveFile(perfPath)
 


### PR DESCRIPTION
Otherwise it never generates the gpu-trace.zip, because args.outpath doesn't exist. :(

Found on SteamOS main.