### PR TITLE
Add amdgpu map/unmap events.

### DIFF
--- a/bin/amdgpu-trace
+++ b/bin/amdgpu-trace
@@ -199,6 +199,9 @@ function startTrace () {
     traceEvents+=" -e amdgpu:amdgpu_sched_run_job"
     traceEvents+=" -e amdgpu:amdgpu_ttm_bo_move"
     traceEvents+=" -e *fence:*fence_signaled"
+    traceEvents+=" -e amdgpu:amdgpu_vm_bo_map"
+    traceEvents+=" -e amdgpu:amdgpu_vm_bo_unmap"
+
 
     # https://github.com/mikesart/gpuvis/wiki/TechDocs-Intel
     #

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -404,6 +404,9 @@ class GpuTrace:
         "amdgpu:amdgpu_sched_run_job",
         "amdgpu:amdgpu_ttm_bo_move",
         "*fence:*fence_signaled",
+        "amdgpu:amdgpu_vm_bo_map",
+        "amdgpu:amdgpu_vm_bo_unmap",
+
 
         # https://github.com/mikesart/gpuvis/wiki/TechDocs-Intel
         #


### PR DESCRIPTION
No visualization in gpuvis, but since kernel sync issues are increasingly around pagetable updates it is nice to have a clue when it happens and who the caller is.