### PR TITLE
Fix kate editor detection.

### DIFF
--- a/bin/amdgpu-trace
+++ b/bin/amdgpu-trace
@@ -103,7 +103,7 @@ function getDefaultReportEditor () {
     fi
 
     if [ -e "$(which kate)" ]; then
-        echo gedit
+        echo kate
         return
     fi
 


### PR DESCRIPTION
If gvim and gedit aren't available, but kate is, don't detect it as gedit, use kate...
I.e. fix the typo in amdgpu-trace when kate is the only editor on the system.