### PR TITLE
Add a duration parameter and collect less data

### DIFF
--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -428,19 +428,30 @@ class GpuTrace:
         self.TraceCmd("snapshot", "-f")
         self.TraceCmd("stop")
 
-    def CaptureTrace(self, path):
+    def PauseTrace(self):
         if not self.IsTraceEnabled():
-            Log.error("Attempted to capture trace, but no trace was enabled")
+            Log.error("Attempted to pause trace, but no trace was enabled")
+            return False
+
+        Log.debug("GPU Trace paused for capture")
+        self.TraceCmd("stop")
+        return True
+
+    def RestartTrace(self):
+        Log.debug("GPU Trace capture resuming")
+        self.TraceCmd("restart")
+
+    def CaptureTrace(self, path):
+        if not self.PauseTrace():
             return False
 
         Log.info(f"GPU Trace capture requested: {path}")
-        self.TraceCmd("stop")
         self.TraceCmd("extract", "-k", "-o", path)
 
         os.chmod(path, self.captureMask)
 
-        Log.debug("GPU Trace capture resuming")
-        self.TraceCmd("restart")
+        self.RestartTrace()
+
         return True
 
     def TraceCmd(self, *args):


### PR DESCRIPTION
This series adds a --duration parameter (default 5 seconds) that selects how much data to keep prior to the capture point.

It also tries to better define a capture point (the moment we stop trace-cmd) to avoid the tail of the dataset being full of capture related duties.

The capture point logic is changed to first stop trace-cmd, then dump perf before dumping and restarting trace-cmd collection in an effort to keep the flurry of trace-cmd activity from pushing any interesting samples out of the perf ring buffer.

As a final optimization, we now do trace-cmd and perf post-processing in separate threads in an attempt to reduce time to visualization.

Marked as draft, as  the perf changes to filter the json output based on a time range are currently under review upstream.