### PR TITLE
Minor fixes

### DIFF
--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -673,7 +673,6 @@ class Daemon:
         Log.info("Daemon shutdown request received")
         _thread.start_new_thread(Daemon.ShutdownWork, (self.server,))
         self.RpcStop(quiet=True)
-        sys.exit()
 
     def CleanupIntermediates(self):
         CleanupTempFiles()

--- a/bin/gpu-trace.py
+++ b/bin/gpu-trace.py
@@ -114,7 +114,7 @@ class DeathError(Exception):
 
 
 def Die(msg, previousException=None):
-    Log.critical(msg)
+    Log.critical(msg, exc_info=previousException)
     if previousException is None or not Log.isEnabledFor(logging.DEBUG):
         sys.exit(-1)
     else:


### PR DESCRIPTION
This adds two minor fixes:

- Propagating exception logging in Die for debugging purposes, which is currently quite difficult. I have yet to actually gather the exception info I'm trying to debug, but hopefully shipping this change will let me.
- Preventing client exit calls from propagating a shutdown error from the server to the client, ensuring a clean exit